### PR TITLE
Openjdk-new-subports (sapmachine)

### DIFF
--- a/java/openjdk/Portfile
+++ b/java/openjdk/Portfile
@@ -27,6 +27,9 @@ the OpenJDK class libraries and the Eclipse OpenJ9 JVM."
 set long_description_oracle \
     "Open-source Oracle builds of OpenJDK, the Java Development Kit, an implementation of the Java SE Platform."
 
+set long_description_sap \
+    "Sap builds of openjdk for everyone who wish to use OpenJDK to run their applications."
+
 set long_description_temurin \
     "Eclipse Temurin provides secure, TCK-tested and compliant, production-ready Java runtimes."
 
@@ -271,6 +274,23 @@ subport openjdk11-openj9-large-heap {
     version      11.0.10
     revision     2
     replaced_by  openjdk11-openj9
+}
+
+subport openjdk11-sap {
+    # https://github.com/SAP/SapMachine/releases/tag/sapmachine-11.0.14
+    version      11.0.14
+    revision     0
+    
+    description  OpenJDK 11 builds (Long Term Support) maintained and supported by SAP
+    long_description ${long_description_sap}
+    
+    master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
+    distname     sapmachine-jdk-${version}_osx-x64_bin
+    worksrcdir   sapmachine-jdk-${version}.jdk
+    
+    checksums    rmd160  e7d313e4ab941463416d32511069932364e048b2 \
+                 sha256  1f8ed571b305ffa058a07484f08056a285302e77f4a8b0ae6af3f2c72a3f8acc \
+                 size    186760702
 }
 
 subport openjdk11-temurin {
@@ -595,6 +615,30 @@ subport openjdk17-oracle {
     worksrcdir   jdk-${version}.jdk
 }
 
+subport openjdk17-sap {
+    # https://github.com/SAP/SapMachine/releases/tag/sapmachine-17.0.2
+    version      17.0.2
+    revision     0
+    
+    description  OpenJDK 17 builds (Long Term Support) maintained and supported by SAP
+    long_description ${long_description_sap}
+    
+    master_sites https://github.com/SAP/SapMachine/releases/download/sapmachine-${version}/
+    
+    if {${configure.build_arch} eq "x86_64"} {
+        distname     sapmachine-jdk-${version}_macos-x64_bin
+        checksums    rmd160  5c2458e509263d50ffdc5a647e2d4f3dd830c8e5 \
+                     sha256  228b9952002dd60e626c46b8ff051e8e25d577d358390cd52dd7e4ea50863cef \
+                     size    180149241
+    } elseif {${configure.build_arch} eq "arm64"} {
+        distname     sapmachine-jdk-${version}_macos-aarch64_bin
+        checksums    rmd160  0aab18f0e415d024d0461ba5ba3f9e2b00f0f4e5 \
+                     sha256  06c28b5365527db346b5d2e121e5f70baaef0ddde07766c59c17bfc577a0e4c2 \
+                     size    177867623
+    }
+    worksrcdir   sapmachine-jdk-${version}.jdk
+}
+
 subport openjdk17-temurin {
     # https://adoptium.net/releases.html?variant=openjdk17&jvmVariant=hotspot
 
@@ -687,6 +731,8 @@ if {[string match *-graalvm ${subport}]} {
     homepage     https://adoptium.net
 } elseif {[string match *-oracle ${subport}]} {
     homepage     https://jdk.java.net
+} elseif {[string match *-sap ${subport}]} {
+    homepage     https://sapmachine.io/
 }
 
 livecheck.type  none


### PR DESCRIPTION
#### Description
Openjdk new subports openjdk11-sap and openjdk17-sap
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->


###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
