### PR TITLE
Openjdk x make builds more specific

### DIFF
--- a/java/openjdk11/Portfile
+++ b/java/openjdk11/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                openjdk11
 # https://github.com/openjdk/jdk11u/tags
 version             11.0.14.1
-revision            3
+revision            4
 categories          java devel
 platforms           darwin
 supported_archs     x86_64 arm64
@@ -55,6 +55,7 @@ configure.args      --with-debug-level=release \
                     --with-native-debug-symbols=none \
                     --with-version-pre=release \
                     --with-jvm-variants=server \
+                    --with-target-bits=64 \
                     --with-sysroot=`xcrun --sdk macosx --show-sdk-path` \
                     --with-extra-cflags="${configure.cflags} ${extrachflags} ${jchflags}" \
                     --with-extra-cxxflags="${configure.cxxflags} ${extracxxflags} ${jcxxflags}" \
@@ -62,7 +63,13 @@ configure.args      --with-debug-level=release \
                     --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk11-bootstrap/Contents/Home \
                     --disable-warnings-as-errors \
                     --disable-precompiled-headers \
-                    --with-conf-name=openjdk${version}
+                    --with-vendor-name="OpenJDK Porters Group" \
+                    --with-vendor-url="${homepage}" \
+                    --with-vendor-bug-url="https://trac.macports.org/newticket?port=${name}" \
+                    --with-vendor-vm-bug-url="https://trac.macports.org/newticket?port=${name}" \
+                    --without-version-opt \
+                    --without-version-pre \
+                    --with-conf-name=release
 
 variant server \
     description {JVM with normal interpreter, and a tiered C1/C2 compiler} {}
@@ -108,7 +115,7 @@ build.type          gnu
 build.target        images
 use_parallel_build  no
 set jdkn jdk-${version}.jdk
-set bundle_dir build/openjdk${version}/images/jdk-bundle/${jdkn}/Contents
+set bundle_dir build/release/images/jdk-bundle/${jdkn}/Contents
 
 test.run            yes
 test.cmd            ${bundle_dir}/Home/bin/java

--- a/java/openjdk13/Portfile
+++ b/java/openjdk13/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                openjdk13
 # https://github.com/openjdk/jdk13u/tags
 version             13.0.10
-revision            3
+revision            4
 categories          java devel
 platforms           darwin
 supported_archs     x86_64
@@ -40,6 +40,7 @@ configure.args      --with-debug-level=release \
                     --with-native-debug-symbols=none \
                     --with-version-pre=release \
                     --with-jvm-variants=server \
+                    --with-target-bits=64 \
                     --with-sysroot=`xcrun --sdk macosx --show-sdk-path` \
                     --with-extra-cflags="${configure.cflags} ${extrachflags} ${jchflags}" \
                     --with-extra-cxxflags="${configure.cxxflags} ${extracxxflags} ${jcxxflags}" \
@@ -47,7 +48,13 @@ configure.args      --with-debug-level=release \
                     --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk13-bootstrap/Contents/Home \
                     --disable-warnings-as-errors \
                     --disable-precompiled-headers \
-                    --with-conf-name=openjdk${version}
+                    --with-vendor-name="OpenJDK Porters Group" \
+                    --with-vendor-url="${homepage}" \
+                    --with-vendor-bug-url="https://trac.macports.org/newticket?port=${name}" \
+                    --with-vendor-vm-bug-url="https://trac.macports.org/newticket?port=${name}" \
+                    --without-version-opt \
+                    --without-version-pre \
+                    --with-conf-name=release
 
 variant server \
     description {JVM with normal interpreter, and a tiered C1/C2 compiler} {}
@@ -84,7 +91,7 @@ build.type          gnu
 build.target        images
 use_parallel_build  no
 set jdkn jdk-${version}.jdk
-set bundle_dir build/openjdk${version}/images/jdk-bundle/${jdkn}/Contents
+set bundle_dir build/release/images/jdk-bundle/${jdkn}/Contents
 
 test.run            yes
 test.cmd            ${bundle_dir}/Home/bin/java

--- a/java/openjdk15/Portfile
+++ b/java/openjdk15/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                openjdk15
 # https://github.com/openjdk/jdk15u/tags
 version             15.0.6
-revision            3
+revision            4
 categories          java devel
 platforms           darwin
 supported_archs     x86_64
@@ -41,6 +41,7 @@ configure.args      --with-debug-level=release \
                     --with-native-debug-symbols=none \
                     --with-version-pre=release \
                     --with-jvm-variants=server \
+                    --with-target-bits=64 \
                     --with-sysroot=`xcrun --sdk macosx --show-sdk-path` \
                     --with-extra-cflags="${configure.cflags} ${extrachflags} ${jchflags}" \
                     --with-extra-cxxflags="${configure.cxxflags} ${extracxxflags} ${jcxxflags}" \
@@ -48,7 +49,13 @@ configure.args      --with-debug-level=release \
                     --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk15-bootstrap/Contents/Home \
                     --disable-warnings-as-errors \
                     --disable-precompiled-headers \
-                    --with-conf-name=openjdk${version}
+                    --with-vendor-name="OpenJDK Porters Group" \
+                    --with-vendor-url="${homepage}" \
+                    --with-vendor-bug-url="https://trac.macports.org/newticket?port=${name}" \
+                    --with-vendor-vm-bug-url="https://trac.macports.org/newticket?port=${name}" \
+                    --without-version-opt \
+                    --without-version-pre \
+                    --with-conf-name=release
 variant server \
     description {JVM with normal interpreter, and a tiered C1/C2 compiler} {}
 
@@ -85,7 +92,7 @@ build.type          gnu
 build.target        images
 use_parallel_build  no
 set jdkn jdk-${version}.jdk
-set bundle_dir build/openjdk${version}/images/jdk-bundle/${jdkn}/Contents
+set bundle_dir build/release/images/jdk-bundle/${jdkn}/Contents
 
 test.run            yes
 test.cmd            ${bundle_dir}/Home/bin/java

--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                openjdk17
 # https://github.com/openjdk/jdk17u/tags
 version             17.0.2
-revision            3
+revision            4
 categories          java devel
 platforms           darwin
 supported_archs     x86_64 arm64
@@ -48,6 +48,7 @@ configure.args      --with-debug-level=release \
                     --with-native-debug-symbols=none \
                     --with-version-pre=release \
                     --with-jvm-variants=server \
+                    --with-target-bits=64 \
                     --with-sysroot=`xcrun --sdk macosx --show-sdk-path` \
                     --with-extra-cflags="${configure.cflags} ${extrachflags} ${jchflags}" \
                     --with-extra-cxxflags="${configure.cxxflags} ${extracxxflags} ${jcxxflags}" \
@@ -55,7 +56,13 @@ configure.args      --with-debug-level=release \
                     --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk17-bootstrap/Contents/Home \
                     --disable-precompiled-headers \
                     --disable-warnings-as-errors \
-                    --with-conf-name=openjdk${version}
+                    --with-vendor-name="OpenJDK Porters Group" \
+                    --with-vendor-url="${homepage}" \
+                    --with-vendor-bug-url="https://trac.macports.org/newticket?port=${name}" \
+                    --with-vendor-vm-bug-url="https://trac.macports.org/newticket?port=${name}" \
+                    --without-version-opt \
+                    --without-version-pre \
+                    --with-conf-name=release
 
 variant server \
     description {JVM with normal interpreter, and a tiered C1/C2 compiler} {}
@@ -93,7 +100,7 @@ build.type          gnu
 build.target        images
 use_parallel_build  no
 set jdkn jdk-${version}.jdk
-set bundle_dir build/openjdk${version}/images/jdk-bundle/${jdkn}/Contents
+set bundle_dir build/release/images/jdk-bundle/${jdkn}/Contents
 
 test.run            yes
 test.cmd            ${bundle_dir}/Home/bin/java

--- a/java/openjdk8/Portfile
+++ b/java/openjdk8/Portfile
@@ -8,7 +8,7 @@ name                openjdk8
 # https://github.com/openjdk/jdk8u/tags
 set u 322
 version             1.8.0_${u}
-revision            1
+revision            2
 categories          java devel
 platforms           darwin
 supported_archs     x86_64
@@ -41,13 +41,29 @@ use_xcode           yes
 use_configure    yes
 configure.cmd       ${prefix}/bin/bash ./configure
 configure.pre_args  --prefix=${tpath}
+set extrachflags "-isysroot `xcrun --sdk macosx --show-sdk-path` -arch ${configure.build_arch}"
+set extracxxflags "-isysroot `xcrun --sdk macosx --show-sdk-path` -arch ${configure.build_arch}"
+set extraldflags "-Wl,-syslibroot,`xcrun --sdk macosx --show-sdk-path` -arch ${configure.build_arch}"
+set jchflags "-Wno-implicit-function-declaration -Wno-unused-parameter"
+set jcxxflags "-Wno-implicit-function-declaration -Wno-unused-parameter"
+set jldflags "-L`xcrun --sdk macosx --show-sdk-path`/usr/lib -L`xcrun --sdk macosx --show-sdk-path`/usr/lib/system"
 # default configure args
 configure.args      --with-boot-jdk=/Library/Java/JavaVirtualMachines/openjdk8-bootstrap/Contents/Home \
                     --with-debug-level=release \
                     --with-freetype-include=${prefix}/include/freetype2 \
                     --with-freetype-lib=${prefix}/lib \
+                    --with-target-bits=64 \
                     --with-jvm-variants=server \
-                    --with-conf-name=openjdk${version}
+                    --with-extra-cflags="${configure.cflags} ${extrachflags} ${jchflags}" \
+                    --with-extra-cxxflags="${configure.cxxflags} ${extracxxflags} ${jcxxflags}" \
+                    --with-extra-ldflags="${configure.ldflags} ${extraldflags} ${jldflags}" \
+                    --with-milestone=fcs \
+                    --with-vendor-name="OpenJDK Porters Group" \
+                    --with-vendor-url="${homepage}" \
+                    --with-vendor-bug-url="https://trac.macports.org/newticket?port=${name}" \
+                    --with-vendor-vm-bug-url="https://trac.macports.org/newticket?port=${name}" \
+                    --with-update-version=${u} \
+                    --with-conf-name=release
 
 variant server \
     description {JVM with normal interpreter and a tiered C1/C2 compiler} {}
@@ -72,8 +88,8 @@ use_parallel_build  no
 worksrcdir          openjdk8
 set jdkn jdk${version}.jdk
 set jren jre${version}.jre
-set jdk_bundle_dir build/openjdk${version}/images/j2sdk-bundle/${jdkn}/Contents
-set jre_bundle_dir build/openjdk${version}/images/j2re-bundle/${jren}/Contents
+set jdk_bundle_dir build/release/images/j2sdk-bundle/${jdkn}/Contents
+set jre_bundle_dir build/release/images/j2re-bundle/${jren}/Contents
 set jdk_path ${tpath}/JavaVirtualMachines/${name}
 set jre_path ${tpath}/JavaVirtualMachines/${name}-jre
 


### PR DESCRIPTION
#### Description
Make builds more specific to provide more proper OpenJDK.
<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
sh -c 'printf "%s\n" "macOS `sw_vers -productVersion` `sw_vers -buildVersion` `uname -m`" "`xcodebuild -version|awk '\''NR==1{x=$0}END{print x" "$NF}'\''`"'|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?
- [x] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
